### PR TITLE
fix: blacklist some keywords from checking common_qa

### DIFF
--- a/ovos_commonqa/locale/ca-es/Alerts.voc
+++ b/ovos_commonqa/locale/ca-es/Alerts.voc
@@ -1,0 +1,11 @@
+alarma
+alarmes
+alerta
+alertes
+campaneta
+desperta'm
+fes-me despertar
+recordatori
+recordatoris
+temporitzador
+temporitzadors

--- a/ovos_commonqa/locale/ca-es/MiscBlacklist.voc
+++ b/ovos_commonqa/locale/ca-es/MiscBlacklist.voc
@@ -1,0 +1,6 @@
+aquesta tarda
+ara mateix
+passat al món
+que hi ha de nou
+skills
+sobre el que fa

--- a/ovos_commonqa/locale/en-us/Alerts.voc
+++ b/ovos_commonqa/locale/en-us/Alerts.voc
@@ -1,0 +1,10 @@
+alarm
+alarms
+alert
+alerts
+reminder
+reminders
+timer
+timers
+wake me
+wake me up

--- a/ovos_commonqa/locale/en-us/MiscBlacklist.voc
+++ b/ovos_commonqa/locale/en-us/MiscBlacklist.voc
@@ -1,0 +1,9 @@
+can you
+happened in the world
+is it
+right now
+skills
+this afternoon
+what time
+what's new
+you do

--- a/ovos_commonqa/locale/es-es/Alerts.voc
+++ b/ovos_commonqa/locale/es-es/Alerts.voc
@@ -1,0 +1,10 @@
+alarma
+alarmas
+alerta
+alertas
+despiértame
+haz que me despierte
+recordatorio
+recordatorios
+temporizador
+temporizadores

--- a/ovos_commonqa/locale/eu/Alerts.voc
+++ b/ovos_commonqa/locale/eu/Alerts.voc
@@ -1,0 +1,10 @@
+alarma
+alarmak
+alerta
+alertak
+denboragailu
+denboragailuak
+esnarazi
+esnarazi nazazu
+gogorarazpen
+gogorarazpenak

--- a/ovos_commonqa/locale/gl-es/Alerts.voc
+++ b/ovos_commonqa/locale/gl-es/Alerts.voc
@@ -1,0 +1,10 @@
+alarma
+alarmas
+alerta
+alertas
+despiértame
+haz que me despierte
+recordatorio
+recordatorios
+temporizador
+temporizadores

--- a/ovos_commonqa/locale/pt-pt/Alerts.voc
+++ b/ovos_commonqa/locale/pt-pt/Alerts.voc
@@ -1,0 +1,10 @@
+acorda-me
+acorda-me mais tarde
+alarme
+alarmes
+alerta
+alertas
+lembrete
+lembretes
+temporizador
+temporizadores

--- a/ovos_commonqa/opm.py
+++ b/ovos_commonqa/opm.py
@@ -98,7 +98,10 @@ class CommonQAService(PipelineStageMatcher, OVOSAbstractApplication):
         if len(utterance.split(" ")) < 3:
             LOG.debug("utterance has less than 3 words, doesnt look like a question")
             return False
-        # skip utterances meant for common play
+        # skip utterances meant for common play / weather / other known conflicts
+        if self.voc_match(utterance, "MiscBlacklist", lang):
+            LOG.debug("utterance has 'blacklist' keywords, doesnt look like a general knowledge question")
+            return False
         if self.voc_match(utterance, "Weather", lang):
             LOG.debug("utterance has 'weather' keywords, doesnt look like a general knowledge question")
             return False

--- a/ovos_commonqa/opm.py
+++ b/ovos_commonqa/opm.py
@@ -105,6 +105,9 @@ class CommonQAService(PipelineStageMatcher, OVOSAbstractApplication):
         if self.voc_match(utterance, "Weather", lang):
             LOG.debug("utterance has 'weather' keywords, doesnt look like a general knowledge question")
             return False
+        if self.voc_match(utterance, "Alerts", lang):
+            LOG.debug("utterance has 'alerts' keywords, doesnt look like a general knowledge question")
+            return False
         if self.voc_match(utterance, "Play", lang):
             LOG.debug("utterance has 'playback' keywords, doesnt look like a general knowledge question")
             return False

--- a/translations/ca-es/vocabs.json
+++ b/translations/ca-es/vocabs.json
@@ -11,6 +11,19 @@
     "passat al món",
     "que hi ha de nou"
   ],
+  "Alerts.voc": [
+    "alerta",
+    "alertes",
+    "temporitzador",
+    "temporitzadors",
+    "recordatori",
+    "recordatoris",
+    "alarma",
+    "alarmes",
+    "campaneta",
+    "desperta'm",
+    "fes-me despertar"
+  ],
   "QuestionWord.voc": [
     "qui",
     "què",

--- a/translations/ca-es/vocabs.json
+++ b/translations/ca-es/vocabs.json
@@ -3,6 +3,14 @@
     "temps",
     "(metereologia|meteorològiques)"
   ],
+  "MiscBlacklist.voc": [
+    "sobre el que fa",
+    "skills",
+    "aquesta tarda",
+    "ara mateix",
+    "passat al món",
+    "que hi ha de nou"
+  ],
   "QuestionWord.voc": [
     "qui",
     "què",

--- a/translations/en-us/vocabs.json
+++ b/translations/en-us/vocabs.json
@@ -1,4 +1,15 @@
 {
+  "MiscBlacklist.voc": [
+    "what time",
+    "is it",
+    "can you",
+    "you do",
+    "skills",
+    "this afternoon",
+    "right now",
+    "happened in the world",
+    "what's new"
+  ],
   "Weather.voc": [
     "weather",
     "meteorology"

--- a/translations/en-us/vocabs.json
+++ b/translations/en-us/vocabs.json
@@ -10,6 +10,18 @@
     "happened in the world",
     "what's new"
   ],
+  "Alerts.voc": [
+    "alert",
+    "alerts",
+    "timer",
+    "timers",
+    "reminder",
+    "reminders",
+    "alarm",
+    "alarms",
+    "wake me",
+    "wake me up"
+  ],
   "Weather.voc": [
     "weather",
     "meteorology"

--- a/translations/es-es/vocabs.json
+++ b/translations/es-es/vocabs.json
@@ -2,6 +2,18 @@
   "Weather.voc": [
     "tiempo"
   ],
+  "Alerts.voc": [
+    "alerta",
+    "alertas",
+    "temporizador",
+    "temporizadores",
+    "recordatorio",
+    "recordatorios",
+    "alarma",
+    "alarmas",
+    "despiértame",
+    "haz que me despierte"
+  ],
   "QuestionWord.voc": [
     "quien",
     "qué",

--- a/translations/eu/vocabs.json
+++ b/translations/eu/vocabs.json
@@ -2,6 +2,18 @@
   "Weather.voc": [
     "eguraldi"
   ],
+  "Alerts.voc": [
+    "alerta",
+    "alertak",
+    "denboragailu",
+    "denboragailuak",
+    "gogorarazpen",
+    "gogorarazpenak",
+    "alarma",
+    "alarmak",
+    "esnarazi",
+    "esnarazi nazazu"
+  ],
   "QuestionWord.voc": [
     "nola",
     "zer",

--- a/translations/gl-es/vocabs.json
+++ b/translations/gl-es/vocabs.json
@@ -2,6 +2,18 @@
   "Weather.voc": [
     "tempo"
   ],
+  "Alerts.voc": [
+    "alerta",
+    "alertas",
+    "temporizador",
+    "temporizadores",
+    "recordatorio",
+    "recordatorios",
+    "alarma",
+    "alarmas",
+    "despiértame",
+    "haz que me despierte"
+  ],
   "QuestionWord.voc": [
     "quen",
     "que",

--- a/translations/pt-pt/vocabs.json
+++ b/translations/pt-pt/vocabs.json
@@ -3,6 +3,18 @@
     "(tempo|clima)",
     "(metereologia|metereológica)"
   ],
+  "Alerts.voc": [
+    "alerta",
+    "alertas",
+    "temporizador",
+    "temporizadores",
+    "lembrete",
+    "lembretes",
+    "alarme",
+    "alarmes",
+    "acorda-me",
+    "acorda-me mais tarde"
+  ],
   "QuestionWord.voc": [
     "quem",
     "(quê|o que|que é)",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new language resources that maintain a block list of phrases in both Catalan and English.
  - Expanded locale vocabulary with additional entries for alerts and notifications in multiple languages, including Spanish, Basque, Portuguese, and Galician.

- **Bug Fixes**
  - Improved filtering logic for question processing to exclude inputs containing blocked phrases, enhancing the accuracy of inquiry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->