### PR TITLE
[codex] Add fr-FR fakewiki locale

### DIFF
--- a/tests/ovos_tskill_fakewiki/locale/fr-FR/More.voc
+++ b/tests/ovos_tskill_fakewiki/locale/fr-FR/More.voc
@@ -1,4 +1,4 @@
 continue
 dis-m'en plus
 en savoir plus
-poursuis
+plus de détails

--- a/tests/ovos_tskill_fakewiki/locale/fr-FR/More.voc
+++ b/tests/ovos_tskill_fakewiki/locale/fr-FR/More.voc
@@ -1,0 +1,4 @@
+continue
+dis-m'en plus
+en savoir plus
+poursuis

--- a/tests/ovos_tskill_fakewiki/locale/fr-FR/no_answer.dialog
+++ b/tests/ovos_tskill_fakewiki/locale/fr-FR/no_answer.dialog
@@ -1,1 +1,1 @@
-les archives sont incomplètes
+Je n'ai rien trouvé dans les archives.

--- a/tests/ovos_tskill_fakewiki/locale/fr-FR/no_answer.dialog
+++ b/tests/ovos_tskill_fakewiki/locale/fr-FR/no_answer.dialog
@@ -1,0 +1,1 @@
+les archives sont incomplètes

--- a/tests/ovos_tskill_fakewiki/locale/fr-FR/search_fakewiki.intent
+++ b/tests/ovos_tskill_fakewiki/locale/fr-FR/search_fakewiki.intent
@@ -1,9 +1,9 @@
-cherche dans le wiki {query}
-cherche le wiki pour {query}
-demande au wiki {query}
+cherche {query} dans le wiki
+cherche {query} sur le wiki
+demande au wiki ce qu'il sait sur {query}
 demande au wiki à propos de {query}
 que dit le wiki à propos de {query}
 que dit le wiki sur {query}
-recherche dans le wiki {query}
-recherche le wiki pour {query}
-recherche wiki sur {query}
+qu'est-ce que le wiki dit sur {query}
+recherche {query} dans le wiki
+recherche {query} sur le wiki

--- a/tests/ovos_tskill_fakewiki/locale/fr-FR/search_fakewiki.intent
+++ b/tests/ovos_tskill_fakewiki/locale/fr-FR/search_fakewiki.intent
@@ -1,0 +1,9 @@
+cherche dans le wiki {query}
+cherche le wiki pour {query}
+demande au wiki {query}
+demande au wiki à propos de {query}
+que dit le wiki à propos de {query}
+que dit le wiki sur {query}
+recherche dans le wiki {query}
+recherche le wiki pour {query}
+recherche wiki sur {query}


### PR DESCRIPTION
## Summary
- Add fr-FR fakewiki test-skill resources for the common query pipeline plugin.
- Polish the fake wiki search and follow-up phrases so they sound natural in voice interaction.
- Preserve `{query}` in every translated search sample and keep resource line counts aligned with en-US.

## Validation
- Line-count and `{query}` placeholder scan for `tests/ovos_tskill_fakewiki/locale/fr-FR`
- `git diff --check origin/dev..HEAD`
- `PYTHONPATH=tests:. python -m unittest tests.test_common_query` currently fails one existing local assertion: `is_question_like("what is a computer", "en-US")` returns false; CI unit tests passed on the PR.

## CI Note
- The failing license job is unrelated to these locale files: `pilosus/action-pip-license-checker` reports `Error` for third-party packages such as `audioop-lts`, `build`, `setuptools`, `urllib3`, and others under Python 3.14.
