### PR TITLE
fix: lift ovos-spec-tools upper bound (spec-tools 1.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "ovos-spec-tools>=0.16.1a2,<1.0.0",
+    "ovos-spec-tools>=0.16.1a2",
     "ovos-plugin-manager>=2.5.0a1,<3.0.0",
     "ovos-bus-client>=2.4.0a1,<3.0.0",
     "ovos-config",


### PR DESCRIPTION
spec-tools crossed to 1.x (1.1.0a1 published) — PR #63 (`fix!`) dropped the handler-trio entries from the namespace migration bridge. Consumers capping `ovos-spec-tools<1.0.0` can no longer resolve against the current stack (e.g. ovos-bus-client 2.6.0a1 requires `ovos-spec-tools>=1.1.0a1`).

This drops the upper bound entirely (keeps the floor) so the stack resolves. Verified: with the uncapped floor, uv resolves `ovos-spec-tools==1.1.0a1` alongside `ovos-bus-client==2.6.0a1` with no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)